### PR TITLE
Unique records on TeamStats tables

### DIFF
--- a/app/models/team_stats/baseball.rb
+++ b/app/models/team_stats/baseball.rb
@@ -27,9 +27,10 @@
 #
 # Indexes
 #
-#  GameID    (GameID)
-#  LeagueID  (LeagueID)
-#  TeamID    (TeamID)
+#  GameID                                         (GameID)
+#  LeagueID                                       (LeagueID)
+#  TeamID                                         (TeamID)
+#  index_TeamStats_Baseball_on_GameID_and_TeamID  (GameID,TeamID) UNIQUE
 #
 
 class TeamStats::Baseball < ActiveRecord::Base

--- a/app/models/team_stats/basketball.rb
+++ b/app/models/team_stats/basketball.rb
@@ -37,9 +37,10 @@
 #
 # Indexes
 #
-#  GameID    (GameID)
-#  LeagueID  (LeagueID)
-#  TeamID    (TeamID)
+#  GameID                                           (GameID)
+#  LeagueID                                         (LeagueID)
+#  TeamID                                           (TeamID)
+#  index_TeamStats_Basketball_on_GameID_and_TeamID  (GameID,TeamID) UNIQUE
 #
 
 class TeamStats::Basketball < ActiveRecord::Base

--- a/db/migrate/20150421140017_add_unique_index_to_team_stats_tables.rb
+++ b/db/migrate/20150421140017_add_unique_index_to_team_stats_tables.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexToTeamStatsTables < ActiveRecord::Migration
+  def change
+    add_index 'TeamStats_Baseball', ['GameID', 'TeamID'], unique: true
+    add_index 'TeamStats_Basketball', ['GameID', 'TeamID'], unique: true
+    add_index 'TeamStats_Football', ['GameID', 'TeamID'], unique: true
+    add_index 'TeamStats_Hockey', ['GameID', 'TeamID'], unique: true
+    add_index 'TeamStats_Soccer', ['GameID', 'TeamID'], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150421131740) do
+ActiveRecord::Schema.define(version: 20150421140017) do
 
   create_table "Games", primary_key: "GameID", force: :cascade do |t|
     t.integer  "LeagueID",     limit: 4,                 null: false
@@ -268,6 +268,7 @@ ActiveRecord::Schema.define(version: 20150421131740) do
     t.datetime "ModifiedDate"
   end
 
+  add_index "TeamStats_Baseball", ["GameID", "TeamID"], name: "index_TeamStats_Baseball_on_GameID_and_TeamID", unique: true, using: :btree
   add_index "TeamStats_Baseball", ["GameID"], name: "GameID", using: :btree
   add_index "TeamStats_Baseball", ["LeagueID"], name: "LeagueID", using: :btree
   add_index "TeamStats_Baseball", ["TeamID"], name: "TeamID", using: :btree
@@ -307,6 +308,7 @@ ActiveRecord::Schema.define(version: 20150421131740) do
     t.datetime "ModifiedDate"
   end
 
+  add_index "TeamStats_Basketball", ["GameID", "TeamID"], name: "index_TeamStats_Basketball_on_GameID_and_TeamID", unique: true, using: :btree
   add_index "TeamStats_Basketball", ["GameID"], name: "GameID", using: :btree
   add_index "TeamStats_Basketball", ["LeagueID"], name: "LeagueID", using: :btree
   add_index "TeamStats_Basketball", ["TeamID"], name: "TeamID", using: :btree
@@ -340,6 +342,7 @@ ActiveRecord::Schema.define(version: 20150421131740) do
     t.datetime "ModifiedDate"
   end
 
+  add_index "TeamStats_Football", ["GameID", "TeamID"], name: "index_TeamStats_Football_on_GameID_and_TeamID", unique: true, using: :btree
   add_index "TeamStats_Football", ["GameID"], name: "GameID", using: :btree
   add_index "TeamStats_Football", ["LeagueID"], name: "LeagueID", using: :btree
   add_index "TeamStats_Football", ["TeamID"], name: "TeamID", using: :btree
@@ -371,6 +374,7 @@ ActiveRecord::Schema.define(version: 20150421131740) do
     t.datetime "ModifiedDate"
   end
 
+  add_index "TeamStats_Hockey", ["GameID", "TeamID"], name: "index_TeamStats_Hockey_on_GameID_and_TeamID", unique: true, using: :btree
   add_index "TeamStats_Hockey", ["GameID"], name: "GameID", using: :btree
   add_index "TeamStats_Hockey", ["LeagueID"], name: "LeagueID", using: :btree
   add_index "TeamStats_Hockey", ["TeamID"], name: "TeamID", using: :btree
@@ -394,6 +398,7 @@ ActiveRecord::Schema.define(version: 20150421131740) do
     t.datetime "ModifiedDate"
   end
 
+  add_index "TeamStats_Soccer", ["GameID", "TeamID"], name: "index_TeamStats_Soccer_on_GameID_and_TeamID", unique: true, using: :btree
   add_index "TeamStats_Soccer", ["GameID"], name: "GameID", using: :btree
   add_index "TeamStats_Soccer", ["LeagueID"], name: "LeagueID", using: :btree
   add_index "TeamStats_Soccer", ["TeamID"], name: "TeamID", using: :btree

--- a/spec/models/team_stats/baseball_spec.rb
+++ b/spec/models/team_stats/baseball_spec.rb
@@ -27,9 +27,10 @@
 #
 # Indexes
 #
-#  GameID    (GameID)
-#  LeagueID  (LeagueID)
-#  TeamID    (TeamID)
+#  GameID                                         (GameID)
+#  LeagueID                                       (LeagueID)
+#  TeamID                                         (TeamID)
+#  index_TeamStats_Baseball_on_GameID_and_TeamID  (GameID,TeamID) UNIQUE
 #
 
 require 'rails_helper'

--- a/spec/models/team_stats/basketball_spec.rb
+++ b/spec/models/team_stats/basketball_spec.rb
@@ -37,9 +37,10 @@
 #
 # Indexes
 #
-#  GameID    (GameID)
-#  LeagueID  (LeagueID)
-#  TeamID    (TeamID)
+#  GameID                                           (GameID)
+#  LeagueID                                         (LeagueID)
+#  TeamID                                           (TeamID)
+#  index_TeamStats_Basketball_on_GameID_and_TeamID  (GameID,TeamID) UNIQUE
 #
 
 require 'rails_helper'


### PR DESCRIPTION
This PR aims to fix the following issues:

- On every TeamStats tables, there were duplicate entries. An unique index was created using the GameID and TeamID attributes to guarantee their uniqueness amongst those tables
- A method called `#update_str_with_conditionals` was created. This method allows updating records on the database using multiple where conditions